### PR TITLE
Temporary fix for files other than image

### DIFF
--- a/projects/core/src/lib/file-item.ts
+++ b/projects/core/src/lib/file-item.ts
@@ -149,7 +149,7 @@ export class FileItem {
 
   /** Generate image thumbnail */
   private generateThumb(): Observable<any> {
-    if (this.config.thumbs) {
+    if (this.config.thumbs && isImage(this.file)) {
       // Update file item state with thumbnail
       return resizeImage(this.file, this.config.thumbWidth, this.config.thumbHeight, this.config.thumbMethod, 1).pipe(
         tap((blob: Blob) => this.updateState({thumbnail: window.URL.createObjectURL(blob)}))


### PR DESCRIPTION
The last version of the package did not accept any file, other than an image file. This push temporarily fixes it, until someone good at Angular development fixes it for good.

Check: https://github.com/MurhafSousli/ngx-fire-uploader/issues/15#issuecomment-461535233